### PR TITLE
feat/mouse controls

### DIFF
--- a/BAKKA Editor/MyForm.h
+++ b/BAKKA Editor/MyForm.h
@@ -4297,12 +4297,50 @@ private: System::Windows::Forms::CheckBox^ HighlightCheckBox;
 		CirclePanel->MouseWheel += gcnew System::Windows::Forms::MouseEventHandler(this, &MyForm::CirclePanel_MouseWheel);
 	}
 	private: System::Void CirclePanel_MouseWheel(System::Object^ sender, System::Windows::Forms::MouseEventArgs^ e) {
-		if (e->Delta > 0)
-		{
-			BeatNum1->Value++;
+		if (Control::ModifierKeys == Keys::Alt) { 
+			// Shift beat division by standard musical quantizations
+			// TODO: take into account time signature?
+			if (BeatNum2->Value < 2) {
+				if (e->Delta > 0) {
+					BeatNum2->Value = 2;
+				}
+				return;
+			}
+			else if (BeatNum2->Value == 2 && e->Delta < 0) {
+				BeatNum2->Value = 1;
+				return;
+			}
+			
+			int low = 0;
+			int high = 1;
+
+			while (!(BeatNum2->Value >= (1 << low) && BeatNum2->Value <= (1 << high))) {
+				low++;
+				high++;
+			}
+			if (e->Delta < 0) {
+				BeatNum2->Value = (1 << low);
+			}
+			else {
+				if (high < 10) {
+					BeatNum2->Value = (1 << (high + 1));
+				}
+			}
+		}
+		else if (Control::ModifierKeys == Keys::Shift) {
+
+		}
+		else if (Control::ModifierKeys == Keys::Control) {
+
 		}
 		else {
-			BeatNum1->Value--;
+			// Scroll by one beat at a time
+			if (e->Delta > 0) {
+				BeatNum1->Value++;
+			}
+			else {
+				BeatNum1->Value--;
+			}
 		}
 	}
 	private: System::Void MyForm_KeyPress(System::Object^ sender, System::Windows::Forms::KeyPressEventArgs^ e) {

--- a/BAKKA Editor/MyForm.h
+++ b/BAKKA Editor/MyForm.h
@@ -41,6 +41,11 @@ const unsigned int update_interval = 4; // update after every 100 milliseconds (
 const int milInMinute = 60000;
 bool scrollBarChanged = false;
 float theCurrentMeasure = 0;
+// Variables for mouse things
+int mouseDownPos = 0;
+int lastMousePos = -1;
+bool rolloverPos = false;
+bool rolloverNeg = false;
 
 
 int findLine(std::list<NotesNode>::iterator nextNode) {
@@ -540,7 +545,6 @@ private: System::Windows::Forms::CheckBox^ HighlightCheckBox;
 			this->backgroundWorker1 = (gcnew System::ComponentModel::BackgroundWorker());
 			this->backgroundWorker2 = (gcnew System::ComponentModel::BackgroundWorker());
 			this->panel1 = (gcnew System::Windows::Forms::Panel());
-			//this->timer1 = (gcnew System::Windows::Forms::Timer(this->components));
 			this->menuStrip->SuspendLayout();
 			this->NoteTypeBox->SuspendLayout();
 			(cli::safe_cast<System::ComponentModel::ISupportInitialize^>(this->VisualHispeed))->BeginInit();
@@ -1550,8 +1554,10 @@ private: System::Windows::Forms::CheckBox^ HighlightCheckBox;
 			resources->ApplyResources(this->CirclePanel, L"CirclePanel");
 			this->CirclePanel->BackColor = System::Drawing::Color::Transparent;
 			this->CirclePanel->Name = L"CirclePanel";
-			this->CirclePanel->Scroll += gcnew System::Windows::Forms::ScrollEventHandler(this, &MyForm::CirclePanel_Scroll);
 			this->CirclePanel->Paint += gcnew System::Windows::Forms::PaintEventHandler(this, &MyForm::CirclePanel_Paint);
+			this->CirclePanel->MouseDown += gcnew System::Windows::Forms::MouseEventHandler(this, &MyForm::CirclePanel_MouseDown);
+			this->CirclePanel->MouseMove += gcnew System::Windows::Forms::MouseEventHandler(this, &MyForm::CirclePanel_MouseMove);
+			this->CirclePanel->MouseUp += gcnew System::Windows::Forms::MouseEventHandler(this, &MyForm::CirclePanel_MouseUp);
 			// 
 			// VisualSettingsBox
 			// 
@@ -1652,12 +1658,6 @@ private: System::Windows::Forms::CheckBox^ HighlightCheckBox;
 			this->panel1->Controls->Add(this->label18);
 			this->panel1->Controls->Add(this->CurrentObjectText);
 			this->panel1->Name = L"panel1";
-			// 
-			// timer1
-			// 
-			//this->timer1->Enabled = true;
-			//this->timer1->Interval = 20;
-			//this->timer1->Tick += gcnew System::EventHandler(this, &MyForm::timer1_Tick);
 			// 
 			// MyForm
 			// 
@@ -2594,6 +2594,9 @@ private: System::Windows::Forms::CheckBox^ HighlightCheckBox;
 		refreshMapOfTime();
 	}
 	private: System::Void InsertButton_Click(System::Object^ sender, System::EventArgs^ e) {
+		InsertObject();
+	}
+	System::Void InsertObject() {
 		NotesNode tempNotesNode;
 		PreChartNode tempPreChartNode;
 
@@ -4289,15 +4292,17 @@ private: System::Windows::Forms::CheckBox^ HighlightCheckBox;
 		Type^ controlType = CirclePanel->GetType();
 		PropertyInfo^ pi = controlType->GetProperty("DoubleBuffered", BindingFlags::Instance | BindingFlags::NonPublic);
 		pi->SetValue(CirclePanel, true);
+
+		// Add MouseWheel event to CirclePanel
+		CirclePanel->MouseWheel += gcnew System::Windows::Forms::MouseEventHandler(this, &MyForm::CirclePanel_MouseWheel);
 	}
-	private: System::Void CirclePanel_Scroll(System::Object^ sender, System::Windows::Forms::ScrollEventArgs^ e) {
-		if (e->ScrollOrientation == ScrollOrientation::VerticalScroll) {
-			if (e->OldValue < e->NewValue) {
-				BeatNum1->Value++;
-			}
-			else {
-				BeatNum1->Value--;
-			}
+	private: System::Void CirclePanel_MouseWheel(System::Object^ sender, System::Windows::Forms::MouseEventArgs^ e) {
+		if (e->Delta > 0)
+		{
+			BeatNum1->Value++;
+		}
+		else {
+			BeatNum1->Value--;
 		}
 	}
 	private: System::Void MyForm_KeyPress(System::Object^ sender, System::Windows::Forms::KeyPressEventArgs^ e) {
@@ -4353,5 +4358,77 @@ private: System::Windows::Forms::CheckBox^ HighlightCheckBox;
 		DrawToGraphics(bufferedGfx->Graphics);
 	}
 	*/
+private: System::Void CirclePanel_MouseDown(System::Object^ sender, System::Windows::Forms::MouseEventArgs^ e) {
+	// Determine location of mouse click in the circle
+	// X and Y are relative to upper left of image
+	float xCen = e->X - (CirclePanel->Width / 2);
+	float yCen = -(e->Y - (CirclePanel->Height / 2));
+	float theta = Math::Atan2(yCen, xCen) * 180.0f / PI;
+	if (theta < 0)
+		theta += 360.0f;
+	PosNum->Value = (int)(theta / 6.0f);
+	mouseDownPos = (int)PosNum->Value;
+	lastMousePos = -1;
+	rolloverPos = false;
+	rolloverNeg = false;
+}
+private: System::Void CirclePanel_MouseUp(System::Object^ sender, System::Windows::Forms::MouseEventArgs^ e) {
+	InsertObject();
+}
+private: System::Void CirclePanel_MouseMove(System::Object^ sender, System::Windows::Forms::MouseEventArgs^ e) {
+	// Calculate angle
+	float xCen = e->X - (CirclePanel->Width / 2);
+	float yCen = -(e->Y - (CirclePanel->Height / 2));
+	float thetaCalc = Math::Atan2(yCen, xCen) * 180.0f / PI;
+	if (thetaCalc < 0)
+		thetaCalc += 360.0f;
+	int theta = thetaCalc / 6.0f;
+	// Left click will alter the note width and possibly the position depending on which direction is being turned
+	if (e->Button == System::Windows::Forms::MouseButtons::Left) {
+		int delta = theta - lastMousePos;
+		// Handle rollover
+		if (delta == -59) {
+			if (rolloverNeg) {
+				rolloverNeg = false;
+			}
+			else {
+				rolloverPos = true;
+			}
+		}
+		else if (delta == 59) {
+			if (rolloverPos) {
+				rolloverPos = false;
+			}
+			else {
+				rolloverNeg = true;
+			}
+		}
+		if (theta == mouseDownPos) {
+			PosNum->Value = mouseDownPos;
+			SizeNum->Value = 1;
+		}
+		else if ((theta > mouseDownPos || rolloverPos) && !rolloverNeg) {
+			PosNum->Value = mouseDownPos;
+			if (rolloverPos) {
+				
+				SizeNum->Value = Math::Min(theta + 60 - mouseDownPos + 1, 60);
+			}
+			else {
+				SizeNum->Value = theta - mouseDownPos + 1;
+			}
+		}
+		else if (theta < mouseDownPos || rolloverNeg) {
+			if (rolloverNeg) {
+				PosNum->Value = theta;
+				SizeNum->Value = Math::Min(mouseDownPos + 60 - theta + 1, 60);
+			}
+			else {
+				PosNum->Value = theta;
+				SizeNum->Value = mouseDownPos - theta + 1;
+			}
+		}
+		lastMousePos = theta;
+	}
+}
 };
 }

--- a/BAKKA Editor/MyForm.resx
+++ b/BAKKA Editor/MyForm.resx
@@ -4304,12 +4304,6 @@ Viewed Note</value>
   <data name="&gt;&gt;backgroundWorker2.Type" xml:space="preserve">
     <value>System.ComponentModel.BackgroundWorker, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;timer1.Name" xml:space="preserve">
-    <value>timer1</value>
-  </data>
-  <data name="&gt;&gt;timer1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Timer, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>MyForm</value>
   </data>
@@ -4333,8 +4327,5 @@ Viewed Note</value>
   </metadata>
   <metadata name="backgroundWorker2.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>181, 59</value>
-  </metadata>
-  <metadata name="timer1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>345, 59</value>
   </metadata>
 </root>


### PR DESCRIPTION
Scroll on CirclePanel to change the current note beat.
Alt+Scroll on CirclePanel changes the note quantization to nearest power of 2. This may need to be changed to account for odd time signatures.
Left Click + Drag will create the note of the current selected type in the area that you click.

Also inadvertently deleted the unused timer. I think visual studio did that on its own.