### PR TITLE
Editor bug fixes

### DIFF
--- a/BAKKA-Editor/CircleView.cs
+++ b/BAKKA-Editor/CircleView.cs
@@ -405,7 +405,7 @@ namespace BAKKA_Editor
                     // Plot highlighted
                     if (highlightSelectedNote)
                     {
-                        if (selectedNoteIndex != -1 && note == chart.Notes[selectedNoteIndex])
+                        if (selectedNoteIndex is not (-1 or -2) && note == chart.Notes[selectedNoteIndex])
                         {
                             bufGraphics.Graphics.DrawArc(HighlightPen, info.Rect, info.StartAngle + 2, info.ArcLength - 4);
                         }

--- a/BAKKA-Editor/MainForm.cs
+++ b/BAKKA-Editor/MainForm.cs
@@ -534,9 +534,11 @@ namespace BAKKA_Editor
 
         private void beat1Numeric_ValueChanged(object sender, EventArgs e)
         {
+            if (valueTriggerEvent == EventSource.None)
+                valueTriggerEvent = EventSource.ManualMeasureSet;
+
             if (beat1Numeric.Value >= beat2Numeric.Value)
             {
-                valueTriggerEvent = EventSource.ManualMeasureSet;
                 measureNumeric.Value++;
                 beat1Numeric.Value = 0; // will send another event
                 return;
@@ -545,14 +547,12 @@ namespace BAKKA_Editor
             {
                 if (measureNumeric.Value > 0)
                 {
-                    valueTriggerEvent = EventSource.ManualMeasureSet;
                     measureNumeric.Value--;
                     beat1Numeric.Value = beat2Numeric.Value - 1; // will send another event
                     return;
                 }
                 else if (measureNumeric.Value == 0)
                 {
-                    valueTriggerEvent = EventSource.ManualMeasureSet;
                     beat1Numeric.Value = 0; // will send another event
                     return;
                 }
@@ -560,8 +560,6 @@ namespace BAKKA_Editor
             updateTime();
             if (currentSong != null && !IsSongPlaying() && valueTriggerEvent != EventSource.TrackBar)
             {
-                if (valueTriggerEvent == EventSource.None)
-                    valueTriggerEvent = EventSource.ManualMeasureSet;
                 songTrackBar.Value = chart.GetTime(new BeatInfo((int)measureNumeric.Value, (int)beat1Numeric.Value * 1920 / (int)beat2Numeric.Value));
             }
 

--- a/BAKKA-Editor/MainForm.cs
+++ b/BAKKA-Editor/MainForm.cs
@@ -507,7 +507,7 @@ namespace BAKKA_Editor
             circleView.DrawHolds(chart, highlightViewedNoteToolStripMenuItem.Checked, selectedNoteIndex);
 
             // Draw notes
-            circleView.DrawNotes(chart, highlightViewedNoteToolStripMenuItem.Checked && selectedNoteIndex != 2, selectedNoteIndex);
+            circleView.DrawNotes(chart, highlightViewedNoteToolStripMenuItem.Checked, selectedNoteIndex);
 
             // Determine if cursor should be showing
             bool showCursor = showCursorToolStripMenuItem.Checked || circleView.mouseDownPos != -1;


### PR DESCRIPTION
I kept breaking the editor while moving between notes and measures.

This fixes how you have to press the up or down buttons twice before the measure or beat list boxes actually change their value and prevents the circle view from trying to draw `chart.Notes[-2]` when `selectedNoteIndex` is -2 to make it not become a giant X.