### PR TITLE
UX: Update selected note upon insertion of new object

### DIFF
--- a/BAKKA-Editor/MainForm.Designer.cs
+++ b/BAKKA-Editor/MainForm.Designer.cs
@@ -96,6 +96,7 @@
             this.showCursorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.showCursorDuringPlaybackToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.highlightViewedNoteToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.selectLastInsertedNoteToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.chartToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.initialChartSettingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.aboutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -960,7 +961,8 @@
             this.viewToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.showCursorToolStripMenuItem,
             this.showCursorDuringPlaybackToolStripMenuItem,
-            this.highlightViewedNoteToolStripMenuItem});
+            this.highlightViewedNoteToolStripMenuItem,
+            this.selectLastInsertedNoteToolStripMenuItem});
             this.viewToolStripMenuItem.Name = "viewToolStripMenuItem";
             this.viewToolStripMenuItem.Size = new System.Drawing.Size(65, 29);
             this.viewToolStripMenuItem.Text = "View";
@@ -989,6 +991,14 @@
             this.highlightViewedNoteToolStripMenuItem.Name = "highlightViewedNoteToolStripMenuItem";
             this.highlightViewedNoteToolStripMenuItem.Size = new System.Drawing.Size(348, 34);
             this.highlightViewedNoteToolStripMenuItem.Text = "Highlight Viewed Note";
+            // selectLastInsertedNoteToolStripMenuItem
+            // 
+            this.selectLastInsertedNoteToolStripMenuItem.Checked = true;
+            this.selectLastInsertedNoteToolStripMenuItem.CheckOnClick = true;
+            this.selectLastInsertedNoteToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.selectLastInsertedNoteToolStripMenuItem.Name = "selectLastInsertedNoteToolStripMenuItem";
+            this.selectLastInsertedNoteToolStripMenuItem.Size = new System.Drawing.Size(285, 26);
+            this.selectLastInsertedNoteToolStripMenuItem.Text = "Select Last Inserted Note";
             // 
             // chartToolStripMenuItem
             // 
@@ -1561,6 +1571,7 @@
         private ToolStripMenuItem showCursorToolStripMenuItem;
         private ToolStripMenuItem showCursorDuringPlaybackToolStripMenuItem;
         private ToolStripMenuItem highlightViewedNoteToolStripMenuItem;
+        private ToolStripMenuItem selectLastInsertedNoteToolStripMenuItem;
         private ToolStripMenuItem chartToolStripMenuItem;
         private ToolStripMenuItem initialChartSettingsToolStripMenuItem;
         private ToolStripMenuItem aboutToolStripMenuItem;

--- a/BAKKA-Editor/MainForm.cs
+++ b/BAKKA-Editor/MainForm.cs
@@ -27,6 +27,7 @@ namespace BAKKA_Editor
         int selectedGimmickIndex = -1;
         int selectedNoteIndex = -1;
         Note lastNote;
+        Note? nextSelectedNote; // so that we know the last newly inserted note
 
         // Music
         ISoundEngine soundEngine = new ISoundEngine();
@@ -80,6 +81,13 @@ namespace BAKKA_Editor
             {
                 chart.Notes = chart.Notes.OrderBy(x => x.Measure).ToList();
                 chart.Gimmicks = chart.Gimmicks.OrderBy(x => x.Measure).ToList();
+                if (nextSelectedNote != null)
+                {
+                    var nextSelectedIndex = chart.Notes.IndexOf(nextSelectedNote);
+                    if (nextSelectedIndex != -1)
+                        selectedNoteIndex = nextSelectedIndex;
+                    nextSelectedNote = null;
+                }
                 if (selectedNoteIndex >= chart.Notes.Count)
                     selectedNoteIndex = chart.Notes.Count - 1;
                 else if (selectedNoteIndex == -1 && chart.Notes.Count > 0)
@@ -1112,6 +1120,8 @@ namespace BAKKA_Editor
                     default:
                         break;
                 }
+                // new object so update the temporary last note to the new one
+                nextSelectedNote = tempNote;
                 chart.Notes.Add(tempNote);
                 chart.IsSaved = false;
                 switch (currentNoteType)
@@ -1126,8 +1136,6 @@ namespace BAKKA_Editor
                         opManager.Push(new InsertNote(chart, tempNote));
                         break;
                 }
-                // new object so update the currently selected note to the new one
-                UpdateNoteLabels(chart.Notes.Count - 1);
             }
         }
 

--- a/BAKKA-Editor/MainForm.cs
+++ b/BAKKA-Editor/MainForm.cs
@@ -123,6 +123,7 @@ namespace BAKKA_Editor
             showCursorToolStripMenuItem.Checked = userSettings.ViewSettings.ShowCursor;
             showCursorDuringPlaybackToolStripMenuItem.Checked = userSettings.ViewSettings.ShowCursorDuringPlayback;
             highlightViewedNoteToolStripMenuItem.Checked = userSettings.ViewSettings.HighlightViewedNote;
+            selectLastInsertedNoteToolStripMenuItem.Checked = userSettings.ViewSettings.SelectLastInsertedNote;
             autoSaveTimer.Interval = userSettings.SaveSettings.AutoSaveInterval * 60000;
             autoSaveTimer.Enabled = true;
 
@@ -1121,7 +1122,8 @@ namespace BAKKA_Editor
                         break;
                 }
                 // new object so update the temporary last note to the new one
-                nextSelectedNote = tempNote;
+                if (selectLastInsertedNoteToolStripMenuItem.Checked)
+                    nextSelectedNote = tempNote;
                 chart.Notes.Add(tempNote);
                 chart.IsSaved = false;
                 switch (currentNoteType)

--- a/BAKKA-Editor/MainForm.cs
+++ b/BAKKA-Editor/MainForm.cs
@@ -1126,6 +1126,8 @@ namespace BAKKA_Editor
                         opManager.Push(new InsertNote(chart, tempNote));
                         break;
                 }
+                // new object so update the currently selected note to the new one
+                UpdateNoteLabels(chart.Notes.Count - 1);
             }
         }
 

--- a/BAKKA-Editor/UserSettings.cs
+++ b/BAKKA-Editor/UserSettings.cs
@@ -17,6 +17,7 @@ namespace BAKKA_Editor
         public bool ShowCursor { get; set; } = true;
         public bool ShowCursorDuringPlayback { get; set; } = false;
         public bool HighlightViewedNote { get; set; } = true;
+        public bool SelectLastInsertedNote { get; set; } = true;
     }
 
     internal class SaveSettings


### PR DESCRIPTION
Doing this lets someone quickly delete a stray note since the last inserted note would be selected automatically, but comes with the con of moving the selection index around automatically.

I have no idea if this is desired behavior or not, but in case it's acceptable behavior I'll leave this PR here.
