### PR TITLE
fix: prevent use of hold button while inserting a hold

### DIFF
--- a/BAKKA-Editor/MainForm.cs
+++ b/BAKKA-Editor/MainForm.cs
@@ -30,6 +30,7 @@ namespace BAKKA_Editor
         Note lastNote;
         Note? nextSelectedNote; // so that we know the last newly inserted note
         Note? endOfChartNote;
+        bool isInsertingHold = false;
 
         // Music
         ISoundEngine soundEngine = new ISoundEngine();
@@ -728,6 +729,10 @@ namespace BAKKA_Editor
 
         private void holdButtonClicked()
         {
+            // don't reset hold state if we're already inserting a hold
+            if (isInsertingHold)
+                return;
+            
             if (noBonusRadio.Checked)
                 SetSelectedObject(NoteType.HoldStartNoBonus);
             else if (bonusRadio.Checked)
@@ -1197,6 +1202,8 @@ namespace BAKKA_Editor
 
         private void SetNonHoldButtonState(bool state)
         {
+            isInsertingHold = !state;
+            
             tapButton.Enabled = state;
             orangeButton.Enabled = state;
             greenButton.Enabled = state;


### PR DESCRIPTION
The hold note type button causes the current type to be set to hold start, which can cause charts to be exported in an invalid way.